### PR TITLE
AddGuestLimitToPark Stretch Goal

### DIFF
--- a/DirtBikePark/Data/BookingRepository.cs
+++ b/DirtBikePark/Data/BookingRepository.cs
@@ -61,6 +61,11 @@ namespace DirtBikePark.Data
             _context.Bookings.Remove(booking);
         }
 
+        public void RemoveBookingsInList(List<Booking> bookings)
+        {
+            _context.RemoveRange(bookings);
+        }
+
         public void Save()
         {
             _context.SaveChanges();

--- a/DirtBikePark/Interfaces/IBookingRepository.cs
+++ b/DirtBikePark/Interfaces/IBookingRepository.cs
@@ -11,6 +11,7 @@ namespace DirtBikePark.Interfaces
         IEnumerable<Booking> GetBookingsForParkWithDate(int parkId, DateOnly date);
         void AddBooking(Booking booking);
         void RemoveBooking(Booking booking);
+        void RemoveBookingsInList(List<Booking> booking);
         void Save();
     }
 }

--- a/DirtBikePark/Services/ParkService.cs
+++ b/DirtBikePark/Services/ParkService.cs
@@ -104,12 +104,16 @@ namespace DirtBikePark.Services
                 throw new InvalidOperationException($"Park with ID {parkId} not found.");
 
             // Assign values then update and save
+            int oldGuestLimit = park.GuestLimit;
             park.PricePerAdult = newPark.PricePerAdult;
             park.PricePerChild = newPark.PricePerChild;
             park.GuestLimit = newPark.GuestLimit;
             _parkRepository.UpdatePark(park);
             _parkRepository.Save();
 
+            // Stretch goal -- remove existing guests over limit on every date
+            if (park.GuestLimit < oldGuestLimit)
+                RemoveGuestsOverNewLimit(parkId, park.GuestLimit);
             return Task.FromResult(true);
         }
 
@@ -125,12 +129,14 @@ namespace DirtBikePark.Services
                 throw new InvalidOperationException($"Park with ID {parkId} not found.");
 
             // Update guest limit and update park in the database
+            int oldGuestLimit = park.GuestLimit;
             park.GuestLimit = numberOfGuests;
             _parkRepository.UpdatePark(park);
             _parkRepository.Save();
 
             // Stretch goal -- remove existing guests over limit on every date
-            RemoveGuestsOverNewLimit(parkId, park.GuestLimit);
+            if (park.GuestLimit < oldGuestLimit)
+                RemoveGuestsOverNewLimit(parkId, park.GuestLimit);
             return Task.FromResult(true);
         }
 


### PR DESCRIPTION
When a new guest limit is assigned to a park, the server now automatically removes bookings that are over the guest limit on any given day, starting with the most-recently created bookings